### PR TITLE
Add resources page

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -169,6 +169,7 @@ NAVIGATION_LINKS = {
         (
             (
                 (CODE_OF_CONDUCT, "Code of Conduct"),
+                ("resources", "Resources"),
                 (LICENSE, "License"),
                 ("/contact", "Contact Us"),
             ),

--- a/conf.py
+++ b/conf.py
@@ -159,7 +159,7 @@ NAVIGATION_LINKS = {
                 ("/2021/registration", "Registration"),
                 ("/2021/schedule", "Schedule"),
                 # ("", "Notebooks & Tutorials"),
-                ("2021/python", "Python Tutorials"),
+                ("/2021/python", "Python Tutorials"),
                 ("/2021/social", "Social Events"),
                 ("/2021/committee", "Organizing Committee"),
             ),
@@ -169,7 +169,7 @@ NAVIGATION_LINKS = {
         (
             (
                 (CODE_OF_CONDUCT, "Code of Conduct"),
-                ("resources", "Resources"),
+                ("/resources", "Resources"),
                 (LICENSE, "License"),
                 ("/contact", "Contact Us"),
             ),

--- a/pages/index.md
+++ b/pages/index.md
@@ -101,6 +101,12 @@ participants who are new to Python.  These tutorials will be held
 the week before the Hack Week on Monday, June 21 and Tuesday, June 22 at
 15 UTC (4 pm CET / 11 am EDT / 8 am PDT).
 
+## Resources
+
+We have compiled [resources](./resources) that are likely to be useful
+for Hack Week participants.  Topics include Python, git/GitHub, and 
+research software engineering best practices.
+
 ## Code of conduct
 
 Plasma Hack Week has adopted the [Contributor Covenant Code of

--- a/pages/resources.md
+++ b/pages/resources.md
@@ -1,0 +1,20 @@
+title: Resources
+hidetitle: True
+
+# Plasma Hack Week: Resources
+
+## Using git and GitHub
+
+ - git
+ - 
+
+## Python tutorials
+
+ - [Research software engineering with Python](https://merely-useful.tech/py-rse/)
+ - NumPy
+ - SciPy
+ - Astropy
+
+## Plasma software
+
+ - PlasmaPy

--- a/pages/resources.md
+++ b/pages/resources.md
@@ -3,18 +3,51 @@ hidetitle: True
 
 # Plasma Hack Week: Resources
 
-## Using git and GitHub
+## Contributing to open source software
 
- - git
- - 
+### Version control
 
-## Python tutorials
+ - [git and GitHub tutorial](https://www.youtube.com/watch?v=xuB1Id2Wxak)
+ - [GitHub Guides](https://guides.github.com/)
 
+### Best practices
+
+ - [Best practices for scientific computing](https://doi.org/10.1371/journal.pbio.1001745) and its prequel [Good enough practices in scientific computing](https://doi.org/10.1371/journal.pcbi.1005510)
+ - [Writing clean scientific software](https://doi.org/10.5281/zenodo.3922956)
+ - [Choose an open source license](https://choosealicense.com/)
+ - [How to cite software](https://libguides.mit.edu/c.php?g=551454&p=3900280)
+
+## Participating software projects
+
+ - [PlasmaPy](https://docs.plasmapy.org/en/latest)
+ - [OMFIT](https://gafusion.github.io/OMFIT-source/)
+ - [BOUT++](https://boutproject.github.io/)
+ - [GKEYLL](https://gkeyll.readthedocs.io/en/latest/)  
+ - [SunPy](https://docs.sunpy.org)
+ - [TurboPy](https://turbopy.readthedocs.io/en/latest/)
+ - [OMAS](https://gafusion.github.io/omas/)
+
+## [Python](https://www.python.org/)
+
+ - [Python documentation](https://docs.python.org/3/) (including a [Python tutorial](https://docs.python.org/3/tutorial/))
  - [Research software engineering with Python](https://merely-useful.tech/py-rse/)
- - NumPy
- - SciPy
- - Astropy
+ - [PEP 8 style guide for Python](https://www.python.org/dev/peps/pep-0008/)
+ 
 
-## Plasma software
+### Scientific Python packages
 
- - PlasmaPy
+ - [NumPy](https://numpy.org/doc/)
+ - [SciPy](https://docs.scipy.org/doc/scipy/reference/)
+ - [matplotlib](https://matplotlib.org/stable/index.html)  
+ - [pandas](https://pandas.pydata.org/)
+ - [xarray](http://xarray.pydata.org/en/stable/)  
+ - [Astropy](https://docs.astropy.org/en/stable/)
+
+### Testing Python software
+
+ - [pytest](https://docs.pytest.org/en/stable/)
+ - [Learn pytest in 60 minutes](https://www.youtube.com/watch?v=bbp_849-RZ4)    
+ 
+### Writing Python documentation
+
+ - [Getting started with Sphinx](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html)

--- a/pages/resources.md
+++ b/pages/resources.md
@@ -3,36 +3,36 @@ hidetitle: True
 
 # Plasma Hack Week: Resources
 
-## Contributing to open source software
+This page contains internet resources that are likely to be helpful to
+Hack Week participants.  For a good general resource on writing software
+for plasma science, we recommend [Research software engineering with
+Python](https://merely-useful.tech/py-rse/).
 
-### Version control
+## Version control
 
  - [git and GitHub tutorial](https://www.youtube.com/watch?v=xuB1Id2Wxak)
  - [GitHub Guides](https://guides.github.com/)
 
-### Best practices
+## [Python](https://www.python.org/)
+ 
+ - [Official Python documentation](https://docs.python.org/3/) (including a [Python tutorial](https://docs.python.org/3/tutorial/))
+ - [PEP 8 style guide for Python](https://www.python.org/dev/peps/pep-0008/)
+ 
+### Testing Python software
+
+ - [pytest](https://docs.pytest.org/en/stable/)
+ - [Learn pytest in 60 minutes](https://www.youtube.com/watch?v=bbp_849-RZ4)    
+ 
+### Writing Python documentation
+
+ - [Getting started with Sphinx](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html)
+
+## Best practices
 
  - [Best practices for scientific computing](https://doi.org/10.1371/journal.pbio.1001745) and its prequel [Good enough practices in scientific computing](https://doi.org/10.1371/journal.pcbi.1005510)
  - [Writing clean scientific software](https://doi.org/10.5281/zenodo.3922956)
  - [Choose an open source license](https://choosealicense.com/)
  - [How to cite software](https://libguides.mit.edu/c.php?g=551454&p=3900280)
-
-## Participating software projects
-
- - [PlasmaPy](https://docs.plasmapy.org/en/latest)
- - [OMFIT](https://gafusion.github.io/OMFIT-source/)
- - [BOUT++](https://boutproject.github.io/)
- - [GKEYLL](https://gkeyll.readthedocs.io/en/latest/)  
- - [SunPy](https://docs.sunpy.org)
- - [TurboPy](https://turbopy.readthedocs.io/en/latest/)
- - [OMAS](https://gafusion.github.io/omas/)
-
-## [Python](https://www.python.org/)
-
- - [Python documentation](https://docs.python.org/3/) (including a [Python tutorial](https://docs.python.org/3/tutorial/))
- - [Research software engineering with Python](https://merely-useful.tech/py-rse/)
- - [PEP 8 style guide for Python](https://www.python.org/dev/peps/pep-0008/)
- 
 
 ### Scientific Python packages
 
@@ -43,11 +43,12 @@ hidetitle: True
  - [xarray](http://xarray.pydata.org/en/stable/)  
  - [Astropy](https://docs.astropy.org/en/stable/)
 
-### Testing Python software
+## Plasma software
 
- - [pytest](https://docs.pytest.org/en/stable/)
- - [Learn pytest in 60 minutes](https://www.youtube.com/watch?v=bbp_849-RZ4)    
- 
-### Writing Python documentation
-
- - [Getting started with Sphinx](https://docs.readthedocs.io/en/stable/intro/getting-started-with-sphinx.html)
+ - [PlasmaPy](https://docs.plasmapy.org/en/latest)
+ - [OMFIT](https://gafusion.github.io/OMFIT-source/)
+ - [BOUT++](https://boutproject.github.io/)
+ - [GKEYLL](https://gkeyll.readthedocs.io/en/latest/)  
+ - [SunPy](https://docs.sunpy.org)
+ - [TurboPy](https://turbopy.readthedocs.io/en/latest/)
+ - [OMAS](https://gafusion.github.io/omas/)

--- a/pages/resources.md
+++ b/pages/resources.md
@@ -15,8 +15,10 @@ Python](https://merely-useful.tech/py-rse/).
 
 ## [Python](https://www.python.org/)
  
- - [Official Python documentation](https://docs.python.org/3/) (including a [Python tutorial](https://docs.python.org/3/tutorial/))
+ - [Official Python documentation](https://docs.python.org/3/) (including
+   a [Python tutorial](https://docs.python.org/3/tutorial/))
  - [PEP 8 style guide for Python](https://www.python.org/dev/peps/pep-0008/)
+ - [Python Tutorial for Beginners](https://www.youtube.com/watch?v=mJEpimi_tFo)
  
 ### Testing Python software
 

--- a/pages/resources.md
+++ b/pages/resources.md
@@ -48,7 +48,7 @@ Python](https://merely-useful.tech/py-rse/).
 ## Plasma software
 
  - [PlasmaPy](https://docs.plasmapy.org/en/latest)
- - [OMFIT](https://gafusion.github.io/OMFIT-source/)
+ - [OMFIT](https://omfit.io)
  - [BOUT++](https://boutproject.github.io/)
  - [GKEYLL](https://gkeyll.readthedocs.io/en/latest/)  
  - [SunPy](https://docs.sunpy.org)


### PR DESCRIPTION
The goal of this PR is to start adding resources for how to learn Python, git/GitHub, etc. and also find links to the software projects that are participating in the hack week (PlasmaPy, OMFIT, BOUT++, TurboPy, SunPy, GKEYLL, etc.).

I'm hoping to add tutorials for most of the important topics, but I also don't want to have so many resources as to make this page overwhelming.

This will persist from year to year, so I did not include it in the 2021 directory.