### PR TITLE
Add the 2021 Hack Week schedule to the schedule page.

### DIFF
--- a/pages/2021/schedule.md
+++ b/pages/2021/schedule.md
@@ -3,27 +3,73 @@ hidetitle: True
 
 # Plasma Hack Week 2021: Schedule
 
+**Dates:** June 28th to July 2nd
+**Times:** 11:00 am to 4:00 pm EDT
+
+<div class="plasmapy-note">
+    <p class="plasmapy-note-title">
+        Prequel tutorials on scientific Python
+    </p>
+    <p>
+        On Monday, Jun 21 and Tuesday, June 22 at 11:00 am EDT we will be holding
+        some pre- Hack Week tutorials focused on using Python for science.  These
+        tutorials are geared towards participants new to Python.
+    </p>
+    <p>
+        For further details please see the <a href="#prequel">prequel</a> section
+        below and/or the <a href="../python">Python tutorial</a> page.
+    </p>
+</div>
+
 Each day of **Plasma Hack Week** will be filled with structured tutorial
 time, social time, and unstructured free hacking time.  All pre-planned
 events will not exceed 5 hours in any given day, and we highly encourage
 any breakout discussions and hack sessions that may be inspired from the
 day's activities.
 
-This year's Hack Week will be held from June 28 to July 2.  The main 
-events each day will be:
+This year's Hack Week will be held from June 28 to July 2.  Each day is divided
+into two 2-hour sessions split between a social hour, see
+[the schedule](#the-schedule) below for details.
 
- * A two-hour session with tutorials, lightning talks, and group discussion
-   from 15:00–17:00 UTC (3–5 pm CET, 11 am – 1 pm ET, 8–10 am PT)
- * A one-hour informal social hour from 17:00–18:00 UTC 
-   (5–6 pm CET, 1–2 pm ET, 10–11 am PT)
- * A two-hour hack session from 18:00–20:00 UTC
-   (6–8 pm CET, 2–4 pm ET, 11 am – 1 pm PT)
-   
-We encourage participants to schedule additional events during the hack
-week, and announce them on Discord. Please stay tuned to this page,
-since more information will be posted here as the details solidify.  
+   First Session
+   : This session is geared towards tutorials and lightning talks with
+     the option for any inspired discussions as we move into the social hour.
 
-## Prequel tutorials on scientific Python
+   Social Hour
+   : The social hour is intended for participants to use as they like, but we
+     highly encourage participants to use this time to interact and discuss
+     with other participants.  During this time the Hack Week organizers
+     will sit in the main meeting to be available for any discussions, but
+     we will also have several breakout rooms available.  These breakout
+     rooms are so participants can have more focused discussions amongst
+     themselves.
+
+   Second Session
+   : The second session is focused more towards open hacking/coding and
+     discussions.  The session will start off with a specific topic
+     to get the ball rolling and then will be opened up to any topics
+     participants are interested in.
+
+During the social hour or second session we highly encourage participants
+to schedule additional events.  If this is something you are interested
+in, then please announce and organize it on Discord.  We will do our best
+to facilitate a breakout room for you.
+
+## <a name="the-schedule"></a> The schedule
+
+<div style="margin: 0; padding: 0; height: 8px"><!-- white space --></div>
+
+<!--
+<iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vThxop98ydoJtxUlCzrgtxSgdutLkjSF1zTs4ollIWhgoUxDdpJPh-PV6MegZ8wuc9hLGZSHoueprTr/pubhtml?gid=2076043769&amp;single=true&amp;widget=true&amp;headers=false"></iframe>
+-->
+
+<iframe 
+   name="2021HW_schedule"
+   style="width: 100%; height: 700px; overflow: hidden; margin-bottom: 18px"
+   src="https://docs.google.com/spreadsheets/d/e/2PACX-1vThxop98ydoJtxUlCzrgtxSgdutLkjSF1zTs4ollIWhgoUxDdpJPh-PV6MegZ8wuc9hLGZSHoueprTr/pubhtml?gid=2076043769&amp;single=true&amp;widget=false&amp;headers=false&amp;chrome=false&amp;range=A1:H32">
+</iframe>
+
+## <a name="prequel"></a> Prequel tutorials on scientific Python
 
 We will hold two [tutorials to introduce Python](../python) to 
 participants who are new to Python.  These tutorials will be held 
@@ -31,7 +77,11 @@ the week before the Hack Week on Monday, June 21 and Tuesday, June 22 at
 15 UTC (4 pm CET / 11 am EDT / 8 am PDT).  Each tutorial will last about
 one hour.
 
-## Tutorials during the Hack Week
+## Types of talks
+
+<div style="margin: 0; padding: 0; height: 8px"><!-- white space --></div>
+
+### Tutorials during the Hack Week
 
 During the Hack Week, we will hold a series of interactive tutorials.
 Some of the tutorials will be longer (≳1 hr) to allow an in-depth
@@ -42,7 +92,7 @@ and writing software tests.  We will also hold shorter tutorials
 (∼30 min) that will provide an interactive demonstration of the
 highlights of a particular software package.
 
-## Lightning talks
+### Lightning talks
 
 A lightning talk is an informal ∼5 minute talk on any topic of interest
 to Hack Week participants.  Example topics include a short demo of plasma


### PR DESCRIPTION
This embeds the google spreadsheet we are using for scheduling the Hack Week into the scheduling page.   As a result, any changes to that google spreadsheet will also update the website.

I also update the wording on the page and put a notice for the prequel events.

The scheduling page now looks like...

<img width="578" alt="image" src="https://user-images.githubusercontent.com/29869348/122693646-7e393780-d1ef-11eb-878a-360d81258604.png">
