### PR TITLE
Add where to get connection information for the Python tutorials

### DIFF
--- a/pages/2021/python.md
+++ b/pages/2021/python.md
@@ -11,6 +11,10 @@ tutorial will last about an hour.  This tutorial will be adapted from
 Software Carpentry's [Programming with Python
 tutorial](https://swcarpentry.github.io/python-novice-inflammation/).
 
+For connection information, please either check the email sent to
+participants or check the `tutorial-python` channel on the
+[Discord channel for the Hack Week](https://discord.gg/HdsZkp9M35).
+
 ## Tentative schedule
 
 Monday, June 21 at 15 UTC


### PR DESCRIPTION
Not putting the Zoom link directly, but rather pointing people to the email and Discord.