### PR TITLE
Create a Tutorial page for the 2021 Hack Week

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -159,7 +159,7 @@ NAVIGATION_LINKS = {
                 ("/2021/about", "About"),
                 ("/2021/registration", "Registration"),
                 ("/2021/schedule", "Schedule"),
-                # ("", "Notebooks & Tutorials"),
+                ("/2021/tutorials", "Tutorials"),
                 ("/2021/python", "Python Tutorials"),
                 ("/2021/social", "Social Events"),
                 ("/2021/committee", "Organizing Committee"),

--- a/data/presenters.json
+++ b/data/presenters.json
@@ -9,8 +9,7 @@
       "abstract": "The plasmapy presentation abstract.",
       "home_url": "https://www.plasmapy.org",
       "repo_url": "https://github.com/plasmapy/plasmapy",
-      "docs_url": "https://docs.plasmapy.org",
-      "message_from_presenter": ""
+      "docs_url": "https://docs.plasmapy.org"
     }
   }
 }

--- a/data/presenters.json
+++ b/data/presenters.json
@@ -1,9 +1,9 @@
 {
   "2021HW": {
-    "dominik": {
+    "day2-1-dominik": {
       "title": "PlasmaPy",
       "anchor": "plasmapy",
-      "time": "Tuesday, June 29th at 8:00 am EDT",
+      "time": "Tuesday, June 29th at 11:00 am ET",
       "presenter": "Dominik Stańczak",
       "coauthors": "PlasmaPy Developers",
       "abstract": "The plasmapy presentation abstract.",

--- a/data/presenters.json
+++ b/data/presenters.json
@@ -15,7 +15,7 @@
       "title": "git and GitHub Tutorial",
       "anchor": "git_github",
       "time": "Monday, June 28th at 2:00 pm ET",
-      "presenter": "Erik T. Everson and Sterling P. Smith",
+      "presenter": "Erik T. Everson and Sterling Smith",
       "coauthors": null,
       "abstract": null,
       "home_url": null,
@@ -70,12 +70,12 @@
       "title": "OMFIT",
       "anchor": "omfit",
       "time": "Wednesday, June 30th at 11:00 am ET",
-      "presenter": "Sterling P. Smith",
-      "coauthors": null,
-      "abstract": null,
-      "home_url": null,
-      "repo_url": null,
-      "docs_url": null
+      "presenter": "Sterling Smith",
+      "coauthors": "Orso Meneghini",
+      "abstract": "I will give an overview of the OMFIT framework, show how an existing physics module works, including its GUI, and show how to start a new module.",
+      "home_url": "https://omfit.io",
+      "repo_url": "https://github.com/gafusion/OMFIT-source",
+      "docs_url": "https://omfit.io"
     },
     "day3-2-xarray": {
       "title": "<code>xarray</code> Tutorial",

--- a/data/presenters.json
+++ b/data/presenters.json
@@ -1,17 +1,83 @@
 {
   "2021HW": {
-    "day2-1-dominik": {
+    "day1-1-helio": {
+      "title": "Python in Heliophysics Community",
+      "anchor": "helio",
+      "time": "Monday, June 28th at 12:10 pm ET",
+      "presenter": "Julie Barnum",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
+    },
+    "day1-2-git_github": {
+      "title": "git and GitHub Tutorial",
+      "anchor": "git_github",
+      "time": "Monday, June 28th at 2:00 pm ET",
+      "presenter": "Erik T. Everson and Sterling P. Smith",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
+    },
+    "day1-3-venv": {
+      "title": "Virtual Environment Setup",
+      "anchor": "venv",
+      "time": "Monday, June 28th at 3:30 pm ET",
+      "presenter": "Erik T. Everson",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
+    },
+    "day2-1-plasmapy": {
       "title": "PlasmaPy",
       "anchor": "plasmapy",
       "time": "Tuesday, June 29th at 11:00 am ET",
-      "presenter": "Dominik Stańczak",
+      "presenter": "Nick Murphy",
       "coauthors": "PlasmaPy Developers",
-      "abstract": "The plasmapy presentation abstract.",
+      "abstract": null,
       "home_url": "https://www.plasmapy.org",
       "repo_url": "https://github.com/plasmapy/plasmapy",
       "docs_url": "https://docs.plasmapy.org"
     },
-    "day3-2-logan": {
+    "day2-2-retention_in_solids": {
+      "title": "Interface between Plasma Physics and Hydrogen in Solids",
+      "anchor": "solids",
+      "time": "Tuesday, June 29th at 12:10 pm ET",
+      "presenter": "Rémi Delaporte-Mathurin",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
+    },
+    "day2-3-contributing": {
+      "title": "<span style='color: #a64d79'>[Hack Session]</span> First Contribution to an Open Source Project",
+      "anchor": "contributing",
+      "time": "Tuesday, June 29th at 2:00 pm ET",
+      "presenter": "Nick Murphy",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
+    },
+    "day3-1-omfit": {
+      "title": "OMFIT",
+      "anchor": "omfit",
+      "time": "Wednesday, June 30th at 11:00 am ET",
+      "presenter": "Sterling P. Smith",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
+    },
+    "day3-2-xarray": {
       "title": "<code>xarray</code> Tutorial",
       "anchor": "xarray",
       "time": "Wednesday, June 30th at 12:10 pm ET",
@@ -21,6 +87,94 @@
       "home_url": "",
       "repo_url": "",
       "docs_url": ""
+    },
+    "day3-3-clean_code": {
+      "title": "<span style='color: #a64d79'>[Hack Session]</span> Clean Coding Refactoring Session",
+      "anchor": "clean_code",
+      "time": "Wednesday, June 30th at 2:00 pm ET",
+      "presenter": "Nick Murphy",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
+    },
+    "day4-1-bout++": {
+      "title": "BOUT++",
+      "anchor": "bout++",
+      "time": "Thursday, July 1st at 11:00 am ET",
+      "presenter": "Ben Dudson",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
+    },
+    "day4-2-gkeyll": {
+      "title": "Gkeyll",
+      "anchor": "gkeyll",
+      "time": "Thursday, July 1st at 11:30 am ET",
+      "presenter": "Jimmy Juno",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
+    },
+    "day4-3-uncertainties": {
+      "title": "Uncertainties",
+      "anchor": "uncertainties",
+      "time": "Thursday, July 1st at 12:10 am ET",
+      "presenter": "Quinn Pratt",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
+    },
+    "day4-4-proton": {
+      "title": "<span style='color: #a64d79'>[Hack Session]</span> Proton Radiography with PlasmaPy",
+      "anchor": "proton",
+      "time": "Thursday, July 1st at 2:00 pm ET",
+      "presenter": "Peter Heuer",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
+    },
+    "day5-1-sunpy": {
+      "title": "SunPy",
+      "anchor": "sunpy",
+      "time": "Friday, July 2nd at 11:00 am ET",
+      "presenter": "Laura Hayes",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
+    },
+    "day5-2-turbopy": {
+      "title": "TurboPy",
+      "anchor": "turboPy",
+      "time": "Friday, July 2nd at 11:30 am ET",
+      "presenter": "Steve Richardson and Paul Adamson",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
     }
-  }
+  },
+  "day5-3-testing": {
+      "title": "Writing Tests for Scientific Software",
+      "anchor": "testing",
+      "time": "Friday, July 2nd at 12:10 pm ET",
+      "presenter": "Dominik Stańczak",
+      "coauthors": null,
+      "abstract": null,
+      "home_url": null,
+      "repo_url": null,
+      "docs_url": null
+    }
 }

--- a/data/presenters.json
+++ b/data/presenters.json
@@ -3,11 +3,14 @@
     "dominik": {
       "title": "PlasmaPy",
       "anchor": "plasmapy",
+      "time": "Tuesday, June 29th at 8:00 am EDT",
       "presenter": "Dominik Stańczak",
       "coauthors": "PlasmaPy Developers",
-      "affiliation": "United Kingdom",
-      "url": "https://github.com/Stephanieyang0",
-      "image": "/images/2021HW/yang.jpg"
+      "abstract": "The plasmapy presentation abstract.",
+      "home_url": "https://www.plasmapy.org",
+      "repo_url": "https://github.com/plasmapy/plasmapy",
+      "docs_url": "https://docs.plasmapy.org",
+      "message_from_presenter": ""
     }
   }
 }

--- a/data/presenters.json
+++ b/data/presenters.json
@@ -28,8 +28,8 @@
       "time": "Monday, June 28th at 3:30 pm ET",
       "presenter": "Erik T. Everson",
       "coauthors": null,
-      "abstract": null,
-      "home_url": null,
+      "abstract": "This tutorial will cover the creation, setup, and use of virtual environments.  Virtual environments allow you to create Python environments with differing dependencies.  This is helpful when you have task X with dependencies A and task Y with dependencies B, but the dependencies A and B conflict.  As a solution, two virtual environments can be created with the needed dependencies which you can then switch between for the two (or more) tasks.",
+      "home_url": "https://github.com/rocco8773",
       "repo_url": null,
       "docs_url": null
     },

--- a/data/presenters.json
+++ b/data/presenters.json
@@ -17,8 +17,8 @@
       "time": "Monday, June 28th at 2:00 pm ET",
       "presenter": "Erik T. Everson and Sterling Smith",
       "coauthors": null,
-      "abstract": null,
-      "home_url": null,
+      "abstract": "In this tutorial we will cover what is <code>git</code> and GitHub; what are their differences; how they work together; and how to use them.  The demonstration will show how to use <code>git</code> and GitHub to version control our software development, which allows us to better collaborate on projects and record the project's development history.",
+      "home_url": "https://github.com/rocco8773",
       "repo_url": null,
       "docs_url": null
     },

--- a/data/presenters.json
+++ b/data/presenters.json
@@ -10,6 +10,17 @@
       "home_url": "https://www.plasmapy.org",
       "repo_url": "https://github.com/plasmapy/plasmapy",
       "docs_url": "https://docs.plasmapy.org"
+    },
+    "day3-2-logan": {
+      "title": "<code>xarray</code> Tutorial",
+      "anchor": "xarray",
+      "time": "Wednesday, June 30th at 12:10 pm ET",
+      "presenter": "Nikolas Logan",
+      "coauthors": "",
+      "abstract": "This tutorial will be a live demonstration of the <code>xarray</code> package. The focus will be on how <code>xarray</code> can be used to make plasma physics code and data more transparent and user friendly. To this end, we will show how <code>xarray</code>'s introduction of array dimensions and attributes \"allows for a more intuitive, more concise, and less error-prone developer experience\".",
+      "home_url": "",
+      "repo_url": "",
+      "docs_url": ""
     }
   }
 }

--- a/data/presenters.json
+++ b/data/presenters.json
@@ -1,0 +1,13 @@
+{
+  "2021HW": {
+    "dominik": {
+      "title": "PlasmaPy",
+      "anchor": "plasmapy",
+      "presenter": "Dominik Stańczak",
+      "coauthors": "PlasmaPy Developers",
+      "affiliation": "United Kingdom",
+      "url": "https://github.com/Stephanieyang0",
+      "image": "/images/2021HW/yang.jpg"
+    }
+  }
+}

--- a/files/assets/css/custom.css
+++ b/files/assets/css/custom.css
@@ -153,7 +153,7 @@ table tr th :last-child, table tr td :last-child {
     padding: 0 16px;
 }
 
-.feature-card:hover {
+.feature-card:not(.nohover):hover {
     box-shadow: 0 4px 8px 0 rgba(142, 176, 202, 0.5);
     border-color: #017BFF
 }

--- a/pages/2021/tutorials.md
+++ b/pages/2021/tutorials.md
@@ -3,6 +3,7 @@ hidetitle: True
 
 # Plasma Hack Week 2021: Tutorials & Presentations
 
-The pre- Hack Week Python tutorials can be found [here](../python).
+The pre- Hack Week Python tutorials can be found on
+[their dedicated tutorial page](../python).
 
 {{% build_presenter_summaries event="2021HW" %}}

--- a/pages/2021/tutorials.md
+++ b/pages/2021/tutorials.md
@@ -1,0 +1,8 @@
+title: 2021 Hack Week Tutorials
+hidetitle: True
+
+# Plasma Hack Week 2021: Tutorials & Presentations
+
+The pre- Hack Week Python tutorials can be found [here](../python).
+
+{{% build_presenter_summaries event="2021HW" %}}

--- a/shortcodes/build_committee.tmpl
+++ b/shortcodes/build_committee.tmpl
@@ -28,7 +28,7 @@
                 <p style="margin: auto">${affiliation}</p>
             </div>
         </div>
-        </a>
+    </a>
 </%def>
 
 

--- a/shortcodes/build_presenter_summaries.tmpl
+++ b/shortcodes/build_presenter_summaries.tmpl
@@ -18,29 +18,28 @@
         repo_url = content["repo_url"]
         docs_url = content["docs_url"]
     %>
-    <a class="feature-link" id="${anchor}">
-        <div class="feature-card nohover"
-             style="height: 100%; width: 100%;
-                    padding: 8px;
-                    background-image: none">
-            <h2>${title}</h2>
-            <p style="margin: 8px 0; font-style: italic; font-size: 90%">${ptime}</p>
-            <b>Presenter(s):</b> ${presenter}<br>
-            % if coauthors:
-                <b>Co-author(s):</b> ${coauthors}<br>
+    <div id="${anchor}"
+         class="feature-card nohover"
+         style="height: 100%; width: 100%;
+                padding: 8px;
+                background-image: none">
+        <h2>${title}</h2>
+        <p style="margin: 8px 0; font-style: italic; font-size: 90%">${ptime}</p>
+        <b>Presenter(s):</b> ${presenter}<br>
+        % if coauthors:
+            <b>Co-author(s):</b> ${coauthors}<br>
+        % endif
+        <p style="margin: 12px 0">
+            <a href="${home_url}">${home_url}</a>
+            % if repo_url:
+                 | <a href="${repo_url}">Repository</a>
             % endif
-            <p style="margin: 12px 0">
-                <a href="${home_url}">${home_url}</a>
-                % if repo_url:
-                     | <a href="${repo_url}">Repository</a>
-                % endif
-                % if docs_url:
-                     | <a href="${docs_url}">Documentation</a>
-                % endif
-            </p>
-            <p style="margin: 0">${abstract}</p>
-        </div>
-    </a>
+            % if docs_url:
+                 | <a href="${docs_url}">Documentation</a>
+            % endif
+        </p>
+        <p style="margin: 0">${abstract}</p>
+    </div>
 </%def>
 
 

--- a/shortcodes/build_presenter_summaries.tmpl
+++ b/shortcodes/build_presenter_summaries.tmpl
@@ -5,25 +5,40 @@
         title = content["title"]
         if title is None or title == "":
             raise ValueError("A valid title must be entered for 'title'.")
-##         affiliation = content["affiliation"]
-##         if affiliation is None:
-##             affiliation == ""
         anchor = content["anchor"]
         if anchor is None:
             anchor = ""
-##         image = content["image"]
-##         if image is None or image == "":
-##             image = "/images/blank-profile-picture-973460_1280-pixabay.png"
+        presenter = content["presenter"]
+        if presenter is None or presenter == "":
+            raise ValueError("A valid presenter name must be entered for 'presenter'.")
+        coauthors = content["coauthors"]
+        ptime = content["time"]
+        abstract = content["abstract"]
+        home_url = content["home_url"]
+        repo_url = content["repo_url"]
+        docs_url = content["docs_url"]
     %>
     <a class="feature-link" name="${anchor}">
-        <div class="feature-card"
+        <div class="feature-card nohover"
              style="height: 100%; width: 100%;
-                    padding: 0;
+                    padding: 8px;
                     background-image: none">
-            <h1>${title}</h1>
-            Presenter(s): ${content["presenter"]}
-            Co-author(s): ${content["coauthors"]}
-
+            <h2>${title}</h2>
+            <p style="margin: 8px 0; font-style: italic; font-size: 90%">${ptime}</p>
+            <b>Presenter(s):</b> ${presenter}<br>
+            % if coauthors:
+                <b>Co-author(s):</b> ${coauthors}<br>
+            % endif
+            <p style="margin: 12px 0">
+                <a href="${home_url}">${home_url}</a>
+                % if repo_url:
+                     | <a href="${repo_url}">Repository</a>
+                % endif
+                % if docs_url:
+                     | <a href="${docs_url}">Documentation</a>
+                % endif
+            </p>
+            <p style="margin: 0">${abstract}</p>
         </div>
     </a>
 </%def>

--- a/shortcodes/build_presenter_summaries.tmpl
+++ b/shortcodes/build_presenter_summaries.tmpl
@@ -1,0 +1,50 @@
+## -*- coding: utf-8 -*-
+
+<%def name="card(content)">
+    <%
+        title = content["title"]
+        if title is None or title == "":
+            raise ValueError("A valid title must be entered for 'title'.")
+##         affiliation = content["affiliation"]
+##         if affiliation is None:
+##             affiliation == ""
+        anchor = content["anchor"]
+        if anchor is None:
+            anchor = ""
+##         image = content["image"]
+##         if image is None or image == "":
+##             image = "/images/blank-profile-picture-973460_1280-pixabay.png"
+    %>
+    <a class="feature-link" name="${anchor}">
+        <div class="feature-card"
+             style="height: 100%; width: 100%;
+                    padding: 0;
+                    background-image: none">
+            <h1>${title}</h1>
+            Presenter(s): ${content["presenter"]}
+            Co-author(s): ${content["coauthors"]}
+
+        </div>
+    </a>
+</%def>
+
+
+<%
+    if event is UNDERFINED:
+        raise AttributeError(
+            "'build_presenter_summaries' requires the name of the event 'event'"
+        )
+    event_dict = global_data["presenters"][event]
+    members = sorted(event_dict.keys(), key=str.casefold)
+%>
+<div class="feature-row"
+     style="margin: 18px auto; text-align: left">
+    % for member in members:
+        <div class="feature-column"
+             style="width: 100%;
+                    padding: 0; margin: 6px 10px;
+                    float: none; display: inline-block">
+            ${self.card(event_dict[member])}
+        </div>
+    % endfor
+</div>

--- a/shortcodes/build_presenter_summaries.tmpl
+++ b/shortcodes/build_presenter_summaries.tmpl
@@ -30,15 +30,25 @@
             <b>Co-author(s):</b> ${coauthors}<br>
         % endif
         <p style="margin: 12px 0">
-            <a href="${home_url}">${home_url}</a>
+            %if home_url:
+                <a href="${home_url}">${home_url}</a>
+                % if repo_url or docs_url:
+                    <spand> | </spand>
+                % endif
+            %endif
             % if repo_url:
-                 | <a href="${repo_url}">Repository</a>
+                <a href="${repo_url}">Repository</a>
+                % if docs_url:
+                    <spand> | </spand>
+                % endif
             % endif
             % if docs_url:
-                 | <a href="${docs_url}">Documentation</a>
+                <a href="${docs_url}">Documentation</a>
             % endif
         </p>
-        <p style="margin: 0">${abstract}</p>
+        %if abstract:
+            <p style="margin: 0">${abstract}</p>
+        %endif
     </div>
 </%def>
 
@@ -56,7 +66,7 @@
     % for member in members:
         <div class="feature-column"
              style="width: 100%;
-                    padding: 0; margin: 6px 10px;
+                    padding: 0; margin: 10px 10px;
                     float: none; display: inline-block">
             ${self.card(event_dict[member])}
         </div>

--- a/shortcodes/build_presenter_summaries.tmpl
+++ b/shortcodes/build_presenter_summaries.tmpl
@@ -18,7 +18,7 @@
         repo_url = content["repo_url"]
         docs_url = content["docs_url"]
     %>
-    <a class="feature-link" name="${anchor}">
+    <a class="feature-link" id="${anchor}">
         <div class="feature-card nohover"
              style="height: 100%; width: 100%;
                     padding: 8px;


### PR DESCRIPTION
This PR setups up the frame work for adding a tutorial/presenters page.  This uses a similar scheme as the committee page (PR #13 ) where I made a shortcode that builds the table based on a JSON file.  As presenters give me titles, authors, urls, abstracts, etc. I can populate the JSON file, which populates the page.  Each summary entry is also anchored so it can be linked to by doing something like <https://www.plasmapy.org/2021/tutorials/#plasmapy> (obviously this won't work until the PR is merged).

The page and it's entries look like...

![image](https://user-images.githubusercontent.com/29869348/122831876-5d301f80-d29f-11eb-8868-31e2a9e075b0.png)
