### PR TITLE
Add exit survey for the 2021 Plasma Hack Week

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -164,6 +164,7 @@ NAVIGATION_LINKS = {
                 ("/2021/install", "Software Installation"),
                 ("/2021/social", "Social Events"),
                 ("/2021/committee", "Organizing Committee"),
+                ("/2021/exit_survey", "How did we do?"),
             ),
             "2021 Event"
         ),

--- a/pages/2021/exit_survey.md
+++ b/pages/2021/exit_survey.md
@@ -1,0 +1,18 @@
+title: 2021 Hack Week Exit Survey
+hidetitle: True
+
+# Plasma Hack Week 2021: Exit Survey
+
+Thank you for join us for our first Plasma Hack Week!  We were amazed
+by the interest and support of the community.  However, as it goes with
+any development, there is always room for improvement.  As such, we
+would like to hear your thoughts on the event, so we can make it even
+better for next year!
+
+<div style="width: 100%; margin: 24px">
+    <a href=https://docs.google.com/forms/d/e/1FAIpQLSeKNwXWmi0A-RtaYD6RIN1Q2sjFIPKX4Plzy72IPBI0ex2wyg/viewform?usp=sf_link
+            class="feature-card feature-link btn-plasmapy-bluegreen" 
+            style="width: 200px">
+        <div>Exit Survey</div>
+    </a>
+</div>

--- a/pages/index.md
+++ b/pages/index.md
@@ -40,14 +40,14 @@ hidetitle: True
     </div>
     <!-- Feature 3 -->
     <div class="feature-column">
-        <a class="feature-link" href="2021/schedule/#the-schedule">
+        <a class="feature-link" href="2021/exit_survey">
         <div class="feature-card" 
               style="background: linear-gradient(to right, 
                                  var(--plasmapy-darkblue) 0%,
                                  var(--plasmapy-bluegreen) 200%);">
             <div>
                 <h1 style="color: #d8d8d8; font-weight: bold">
-                    Schedule
+                    How did we do?
                 </h1>
             </div>
         </div>


### PR DESCRIPTION
1. Creates a exit survey page for the 2021 Hack Week and links to the associated google form.
2. Places a link to the exit survey page in one of the feature cards on the landing page.

----

**Exit Survey Page**

![image](https://user-images.githubusercontent.com/29869348/123845493-1bb7f980-d8c9-11eb-8b3d-b4fbb09e6b5e.png)

![image](https://user-images.githubusercontent.com/29869348/123845351-ef03e200-d8c8-11eb-952f-f05ef24366f5.png)


----

**Landing Page**

![image](https://user-images.githubusercontent.com/29869348/123845260-d72c5e00-d8c8-11eb-9f5f-56a9bdc42fba.png)
