### PR TITLE
 Add Uncertainty info to Tutorial page

### DIFF
--- a/data/presenters.json
+++ b/data/presenters.json
@@ -127,10 +127,11 @@
       "time": "Thursday, July 1st at 12:10 am ET",
       "presenter": "Quinn Pratt",
       "coauthors": null,
-      "abstract": null,
-      "home_url": null,
-      "repo_url": null,
-      "docs_url": null
+      "abstract": "We will discuss linear error propagation theory, and the \"uncertainties\" python package. We will go through two examples illustrating how to handle uncertainties on fits, and propagation through simulation.",
+      "home_url": "https://docs.google.com/presentation/d/1eXwzobFoJTUb0h-y5ECiRQIm_mDFAW9RGLNbEYO6p1g/edit?usp=sharing",
+      "home_url_txt": "Slides",
+      "repo_url": "https://github.com/quinntpratt/uncertainty-quantification",
+      "docs_url": "https://pythonhosted.org/uncertainties/"
     },
     "day4-4-radiography": {
       "title": "<span style='color: #a64d79'>[Hack Session]</span> Charged Particle Radiography with PlasmaPy",

--- a/shortcodes/build_presenter_summaries.tmpl
+++ b/shortcodes/build_presenter_summaries.tmpl
@@ -17,6 +17,10 @@
         home_url = content["home_url"]
         repo_url = content["repo_url"]
         docs_url = content["docs_url"]
+        try:
+            home_url_txt = content["home_url_txt"]
+        except KeyError:
+            home_url_txt = home_url
     %>
     <div id="${anchor}"
          class="feature-card nohover"
@@ -31,7 +35,7 @@
         % endif
         <p style="margin: 12px 0">
             %if home_url:
-                <a href="${home_url}">${home_url}</a>
+                <a href="${home_url}">${home_url_txt}</a>
                 % if repo_url or docs_url:
                     <spand> | </spand>
                 % endif


### PR DESCRIPTION
Add the Uncertainty tutorial info to the Tutorial page as per the completed google form.

Also updated shortcode so the home_url text can be overridden with a `"home_url_txt"` entry in the JSON file.