### PR TITLE
Add CI for codespell

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -9,7 +9,25 @@ on:
 
 jobs:
 
-  initial-tests:
+  spellcheck:
+  
     name: Codespell
     runs-on: ubuntu-latest
-    run: nox -s codespell
+
+    steps:
+
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.10'
+
+    - name: Install nox
+      run: python -m pip install --progress-bar off --upgrade nox
+
+    - name: Run tests
+      run: nox -s codespell

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,15 @@
+name: Codespell
+
+on:
+  push:
+    branches:
+    - src
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+
+  initial-tests:
+    name: Codespell
+    runs-on: ubuntu-latest
+    run: nox -s codespell

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -30,4 +30,4 @@ jobs:
       run: python -m pip install --progress-bar off --upgrade nox
 
     - name: Run tests
-      run: nox -s codespell
+      run: nox -s codespell --forcecolor

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,18 @@
+"""
+Contains configurations for the nox test runner.
+
+To execute the `codespell` session (for example), run:
+
+  pip install nox
+  nox -s codespell
+"""
+
+import nox
+
+nox.options.sessions = ["codespell"]
+
+
+@nox.session
+def codespell(session):
+    session.install("codespell")
+    session.run("codespell", "pages", "README.md", "noxfile.py")


### PR DESCRIPTION
This adds a [nox](https://nox.thea.codes/en/stable/) configuration file and a GitHub Action to execute [codespell](https://github.com/codespell-project/codespell).