### PR TITLE
Add the 2022 Hack Week schedule

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -158,7 +158,7 @@ NAVIGATION_LINKS = {
             (
                 ("/2022/about", "About"),
                 ("/2022/registration", "Registration"),
-                # ("/2022/schedule", "Schedule"),
+                ("/2022/schedule", "Schedule"),
                 # ("/2022/python", "Python Tutorials"),
                 # ("/2022/tutorials", "Tutorials"),
                 # ("/2022/install", "Software Installation"),

--- a/pages/2022/about.md
+++ b/pages/2022/about.md
@@ -17,8 +17,8 @@ hidetitle: True
     <p style="margin-bottom: 0">
         <a href="../about">About</a><br>
         <a href="../registration">Registration</a><br>
-        <!--
         <a href="../schedule">Schedule</a><br>
+        <!--
         <a href="../python">Python Tutorials</a><br>
         <a href="../tutorials">Tutorials</a><br>
         <a href="../install">Software Installation</a><br>

--- a/pages/2022/schedule.md
+++ b/pages/2022/schedule.md
@@ -1,0 +1,104 @@
+title: 2022 Hack Week Schedule
+hidetitle: True
+
+# Plasma Hack Week 2021: Schedule
+
+**Dates:** July 11th to July 15th
+**Times:** 11:00 am to 4:00 pm EDT
+
+<div class="plasmapy-note">
+    <p class="plasmapy-note-title">
+        Prequel tutorials on scientific Python
+    </p>
+    <p>
+        On Monday, Jun 21 and Tuesday, June 22 at 11:00 am EDT we will be holding
+        some pre- Hack Week tutorials focused on using Python for science.  These
+        tutorials are geared towards participants new to Python.
+    </p>
+    <p>
+        For further details please see the <a href="#prequel">prequel</a> section
+        below and/or the <a href="../python">Python tutorial</a> page.
+    </p>
+</div>
+
+Each day of **Plasma Hack Week** will be filled with structured tutorial
+time, social time, and unstructured free hacking time.  All pre-planned
+events will not exceed 5 hours in any given day, and we highly encourage
+any breakout discussions and hack sessions that may be inspired from the
+day's activities.
+
+This year's Hack Week will be held from June 28 to July 2.  Each day is divided
+into two 2-hour sessions split between a social hour, see
+[the schedule](#the-schedule) below for details.
+
+   First Session
+   : This session is geared towards tutorials and lightning talks with
+     the option for any inspired discussions as we move into the social hour.
+
+   Social Hour
+   : The social hour is intended for participants to use as they like, but we
+     highly encourage participants to use this time to interact and discuss
+     with other participants.  During this time the Hack Week organizers
+     will sit in the main meeting to be available for any discussions, but
+     we will also have several breakout rooms available.  These breakout
+     rooms are so participants can have more focused discussions amongst
+     themselves.
+
+   Second Session
+   : The second session is focused more towards open hacking/coding and
+     discussions.  The session will start off with a specific topic
+     to get the ball rolling and then will be opened up to any topics
+     participants are interested in.
+
+During the social hour or second session we highly encourage participants
+to schedule additional events.  If this is something you are interested
+in, then please announce and organize it on Discord.  We will do our best
+to facilitate a breakout room for you.
+
+## <a name="the-schedule"></a> The schedule
+
+<div style="margin: 0; padding: 0; height: 8px"><!-- white space --></div>
+
+<!--
+<iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vThxop98ydoJtxUlCzrgtxSgdutLkjSF1zTs4ollIWhgoUxDdpJPh-PV6MegZ8wuc9hLGZSHoueprTr/pubhtml?gid=2076043769&amp;single=true&amp;widget=true&amp;headers=false"></iframe>
+-->
+
+<iframe 
+   name="2021HW_schedule"
+   style="width: 100%; height: 700px; overflow: hidden; margin-bottom: 18px"
+   src="https://docs.google.com/spreadsheets/d/e/2PACX-1vThxop98ydoJtxUlCzrgtxSgdutLkjSF1zTs4ollIWhgoUxDdpJPh-PV6MegZ8wuc9hLGZSHoueprTr/pubhtml?gid=2076043769&amp;single=true&amp;widget=false&amp;headers=false&amp;chrome=false&amp;range=A1:H32">
+</iframe>
+
+## <a name="prequel"></a> Prequel tutorials on scientific Python
+
+We will hold two [tutorials to introduce Python](../python) to 
+participants who are new to Python.  These tutorials will be held 
+the week before the Hack Week on Monday, June 21 and Tuesday, June 22 at
+15 UTC (5 pm CEST / 11 am EDT / 8 am PDT).  Each tutorial will last about
+one hour.
+
+## Types of talks
+
+<div style="margin: 0; padding: 0; height: 8px"><!-- white space --></div>
+
+### Tutorials during the Hack Week
+
+During the Hack Week, we will hold a series of interactive tutorials.
+Some of the tutorials will be longer (≳1 hr) to allow an in-depth
+introduction to a particular software package or technique.  Likely 
+topics include version control with git/GitHub, how to contribute to an
+open source software project, getting started with PlasmaPy or OMFIT,
+and writing software tests.  We will also hold shorter tutorials 
+(∼30 min) that will provide an interactive demonstration of the
+highlights of a particular software package.
+
+### Lightning talks
+
+A lightning talk is an informal ∼5 minute talk on any topic of interest
+to Hack Week participants.  Example topics include a short demo of plasma
+software, a hack week project idea, an upcoming event, a suggestion for
+improving the culture of the plasma software community, something you
+learned during the Hack Week, an upcoming event, or an idea for plasma
+software that is yet to be developed.  The time allowed for each
+lightning talk will depend on how many people sign up.  There may be
+time during the Hack Week to request a lightning talk as well.

--- a/pages/2022/schedule.md
+++ b/pages/2022/schedule.md
@@ -1,24 +1,24 @@
 title: 2022 Hack Week Schedule
 hidetitle: True
 
-# Plasma Hack Week 2021: Schedule
+# Plasma Hack Week 2022: Schedule
 
 **Dates:** July 11th to July 15th <br>
 **Times:** 11:00 am to 4:00 pm EDT
 
 Each day of this year's **Plasma Hack Week** is focused around hacking,
-so  come prepared to code and have fun!  While each day is centered
-around hack, there will still be planned social time and lightning talks.
+so come prepared to code and have fun!  While each day is centered
+around hacking, there will still be planned social time and lightning talks.
 All pre-planned events will not exceed 5 hours in any given day, and we
 highly encourage any breakout discussions and hack sessions that may be
-inspired from the  day's activities.
+inspired from the day's activities.
 
 This year's Hack Week will be held from July 11 to July 15.  The primary
 goal of this year's event is to teach members of the Plasma community
 the skills needed to contribute to open-source software and develop code
 for the Plasma community as a whole.  The week will start off with
 foundational topics and progress to more advanced topics as the week
-proceeds.  The detailed schedule can be view [below](#the-schedule) and
+proceeds.  The detailed schedule can be viewed [below](#the-schedule) and
 the overview is as follows:
 
    Day 1 (foundational)
@@ -26,7 +26,7 @@ the overview is as follows:
      for developing open-source Python software.
 
    Day 2 (foundational)
-   : The second day is all about version control `git` and
+   : The second day is all about version control with [`git`](https://git-scm.com/) and
      [GitHub](https://github.com/about).  These are the two primary
      tools used to collaboratively develop open-source software.
 
@@ -43,11 +43,11 @@ the overview is as follows:
    : The last two days will focus on developing functionality participants
      are interested in, which can be suggested by any participant and/or
      select from pre-outlined 
-     [project Issues](https://github.com/PlasmaPy/hack-week/issues?q=is%3Aissue+is%3Aopen+label%3A2022).
+     [project issues](https://github.com/PlasmaPy/hack-week/issues?q=is%3Aissue+is%3Aopen+label%3A2022).
 
 Since this year's event is focused on hacking and learning by doing, it
-is in its nature freeform.  So, feel free to bring up any topic you are
-interested; ask any question you might have; and/or launch any breakout
+is in its nature free-form.  So, feel free to bring up any topic you are
+interested in; ask any question you might have; and/or launch any breakout
 discuss to explore your ideas.
 
 ## <a name="the-schedule"></a> The schedule

--- a/pages/2022/schedule.md
+++ b/pages/2022/schedule.md
@@ -3,98 +3,70 @@ hidetitle: True
 
 # Plasma Hack Week 2021: Schedule
 
-**Dates:** July 11th to July 15th
+**Dates:** July 11th to July 15th <br>
 **Times:** 11:00 am to 4:00 pm EDT
 
-<div class="plasmapy-note">
-    <p class="plasmapy-note-title">
-        Prequel tutorials on scientific Python
-    </p>
-    <p>
-        On Monday, Jun 21 and Tuesday, June 22 at 11:00 am EDT we will be holding
-        some pre- Hack Week tutorials focused on using Python for science.  These
-        tutorials are geared towards participants new to Python.
-    </p>
-    <p>
-        For further details please see the <a href="#prequel">prequel</a> section
-        below and/or the <a href="../python">Python tutorial</a> page.
-    </p>
-</div>
+Each day of this year's **Plasma Hack Week** is focused around hacking,
+so  come prepared to code and have fun!  While each day is centered
+around hack, there will still be planned social time and lightning talks.
+All pre-planned events will not exceed 5 hours in any given day, and we
+highly encourage any breakout discussions and hack sessions that may be
+inspired from the  day's activities.
 
-Each day of **Plasma Hack Week** will be filled with structured tutorial
-time, social time, and unstructured free hacking time.  All pre-planned
-events will not exceed 5 hours in any given day, and we highly encourage
-any breakout discussions and hack sessions that may be inspired from the
-day's activities.
+This year's Hack Week will be held from July 11 to July 15.  The primary
+goal of this year's event is to teach members of the Plasma community
+the skills needed to contribute to open-source software and develop code
+for the Plasma community as a whole.  The week will start off with
+foundational topics and progress to more advanced topics as the week
+proceeds.  The detailed schedule can be view [below](#the-schedule) and
+the overview is as follows:
 
-This year's Hack Week will be held from June 28 to July 2.  Each day is divided
-into two 2-hour sessions split between a social hour, see
-[the schedule](#the-schedule) below for details.
+   Day 1 (foundational)
+   : The first day focuses on how to set up your system in preparation
+     for developing open-source Python software.
 
-   First Session
-   : This session is geared towards tutorials and lightning talks with
-     the option for any inspired discussions as we move into the social hour.
+   Day 2 (foundational)
+   : The second day is all about version control `git` and
+     [GitHub](https://github.com/about).  These are the two primary
+     tools used to collaboratively develop open-source software.
 
-   Social Hour
-   : The social hour is intended for participants to use as they like, but we
-     highly encourage participants to use this time to interact and discuss
-     with other participants.  During this time the Hack Week organizers
-     will sit in the main meeting to be available for any discussions, but
-     we will also have several breakout rooms available.  These breakout
-     rooms are so participants can have more focused discussions amongst
-     themselves.
+   Day 3 (intermediate)
+   : In the third day we start developing our own open-source package,
+     the [`hack`](https://github.com/PlasmaPy/hack-week) package.  To
+     start the package we'll develop a plasma formulary using the
+     `plasmapy.formulary` 
+     ([pkg](https://github.com/PlasmaPy/PlasmaPy/tree/main/plasmapy/formulary) |
+     [docs](https://docs.plasmapy.org/en/latest/formulary/index.html))
+     as our guide.
 
-   Second Session
-   : The second session is focused more towards open hacking/coding and
-     discussions.  The session will start off with a specific topic
-     to get the ball rolling and then will be opened up to any topics
-     participants are interested in.
+   Day 4 & 5 (intermediate/advanced)
+   : The last two days will focus on developing functionality participants
+     are interested in, which can be suggested by any participant and/or
+     select from pre-outlined 
+     [project Issues](https://github.com/PlasmaPy/hack-week/issues?q=is%3Aissue+is%3Aopen+label%3A2022).
 
-During the social hour or second session we highly encourage participants
-to schedule additional events.  If this is something you are interested
-in, then please announce and organize it on Discord.  We will do our best
-to facilitate a breakout room for you.
+Since this year's event is focused on hacking and learning by doing, it
+is in its nature freeform.  So, feel free to bring up any topic you are
+interested; ask any question you might have; and/or launch any breakout
+discuss to explore your ideas.
 
 ## <a name="the-schedule"></a> The schedule
 
 <div style="margin: 0; padding: 0; height: 8px"><!-- white space --></div>
 
 <!--
-<iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vThxop98ydoJtxUlCzrgtxSgdutLkjSF1zTs4ollIWhgoUxDdpJPh-PV6MegZ8wuc9hLGZSHoueprTr/pubhtml?gid=2076043769&amp;single=true&amp;widget=true&amp;headers=false"></iframe>
+<iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vRPRayajKEzzmfIi8B9hpvUQ3SJLWTXJ3ktr3XlW6CubXOgoOlQK66qYsTzMHxCG1wZW-iySIs_IkIM/pubhtml?gid=829020640&amp;single=true&amp;widget=true&amp;headers=false"></iframe>
 -->
 
 <iframe 
    name="2021HW_schedule"
    style="width: 100%; height: 700px; overflow: hidden; margin-bottom: 18px"
-   src="https://docs.google.com/spreadsheets/d/e/2PACX-1vThxop98ydoJtxUlCzrgtxSgdutLkjSF1zTs4ollIWhgoUxDdpJPh-PV6MegZ8wuc9hLGZSHoueprTr/pubhtml?gid=2076043769&amp;single=true&amp;widget=false&amp;headers=false&amp;chrome=false&amp;range=A1:H32">
+   src="https://docs.google.com/spreadsheets/d/e/2PACX-1vRPRayajKEzzmfIi8B9hpvUQ3SJLWTXJ3ktr3XlW6CubXOgoOlQK66qYsTzMHxCG1wZW-iySIs_IkIM/pubhtml?gid=829020640&amp;single=true&amp;widget=false&amp;headers=false&amp;chrome=false&amp;range=A1:H32">
 </iframe>
 
-## <a name="prequel"></a> Prequel tutorials on scientific Python
+## Lightning talks
 
-We will hold two [tutorials to introduce Python](../python) to 
-participants who are new to Python.  These tutorials will be held 
-the week before the Hack Week on Monday, June 21 and Tuesday, June 22 at
-15 UTC (5 pm CEST / 11 am EDT / 8 am PDT).  Each tutorial will last about
-one hour.
-
-## Types of talks
-
-<div style="margin: 0; padding: 0; height: 8px"><!-- white space --></div>
-
-### Tutorials during the Hack Week
-
-During the Hack Week, we will hold a series of interactive tutorials.
-Some of the tutorials will be longer (≳1 hr) to allow an in-depth
-introduction to a particular software package or technique.  Likely 
-topics include version control with git/GitHub, how to contribute to an
-open source software project, getting started with PlasmaPy or OMFIT,
-and writing software tests.  We will also hold shorter tutorials 
-(∼30 min) that will provide an interactive demonstration of the
-highlights of a particular software package.
-
-### Lightning talks
-
-A lightning talk is an informal ∼5 minute talk on any topic of interest
+A lightning talk is an informal 2-5 minute talk on any topic of interest
 to Hack Week participants.  Example topics include a short demo of plasma
 software, a hack week project idea, an upcoming event, a suggestion for
 improving the culture of the plasma software community, something you

--- a/pages/index.md
+++ b/pages/index.md
@@ -40,7 +40,7 @@ hidetitle: True
     </div>
     <!-- Feature 3 -->
     <div class="feature-column">
-        <a class="feature-link" href="2021/exit_survey">
+        <a class="feature-link" href="2022/exit_survey">
         <div class="feature-card" 
               style="background: linear-gradient(to right, 
                                  var(--plasmapy-darkblue) 0%,
@@ -58,7 +58,7 @@ hidetitle: True
 Hello world!  We are pleased to announce the return of the **Plasma
 Hack Week**, which will be held remotely from July 11 – July 15, 2022.  For
 additional information please check out the
-[2022 About page](./2021/about), and stay tuned as more details are
+[2022 About page](./2022/about), and stay tuned as more details are
 released.
 
 ## What is a hack week and hacking?
@@ -100,7 +100,7 @@ For information about registering please check out our
 <!--
 ## Installing software for the Hack Week
 
-Please follow these [installation instructions](/2021/install) if you
+Please follow these [installation instructions](/2022/install) if you
 would like to install any of the software needed for the Hack Week.
 
 Alternatively, clicking on the following binder link will initialize a
@@ -108,7 +108,7 @@ Python environment that can be run from your browser.  This environment
 will have most of the Python packages needed for the week pre-installed,
 along with `git`. 
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/PlasmaPy/hack-week-2021/HEAD)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/PlasmaPy/hack-week/HEAD)
 -->
 
 ## Resources
@@ -125,7 +125,7 @@ Conduct](https://www.contributor-covenant.org/version/2/0/code_of_conduct/).
 <!--
 ## Python tutorials
 
-We held two [tutorials to introduce Python](./2021/python) to 
+We held two [tutorials to introduce Python](./2022/python) to 
 participants who are new to Python.  These tutorials were held 
 the week before the Hack Week on Monday, June 21 and Tuesday, June 22 at
 15 UTC (5 pm CEST / 11 am EDT / 8 am PDT).

--- a/pages/index.md
+++ b/pages/index.md
@@ -58,7 +58,7 @@ hidetitle: True
 Hello world!  We are pleased to announce the return of the **Plasma
 Hack Week**, which will be held remotely from July 11 – July 15, 2022.  For
 additional information please check out the
-[2022 About page](./2021/schedule), and stay tuned as more details are
+[2022 About page](./2021/about), and stay tuned as more details are
 released.
 
 ## What is a hack week and hacking?


### PR DESCRIPTION
This PR creates the 2022 Hack Week scheduled.

* The schedule page was mostly copied from the 2021 page, but with updated wording.
* The 2022 schedule developed in google docs is embedded on the schedule page.
* A few erroneous 2021 links on the landing page were updated to point to the 2022 content.
* The 2022 schedule page was exposed to the top menu and 2022 about page.