### PR TITLE
Announce PlasmaPy Summer School 2024

### DIFF
--- a/pages/2024/about.md
+++ b/pages/2024/about.md
@@ -1,0 +1,41 @@
+title: About 2022 Hack Week
+hidetitle: True
+
+# PlasmaPy Summer School 2024
+**Dates:** July 29 – August 1, 2024
+
+<div class="plasmapy-note" 
+     style="max-width: 300px;
+            margin-top: 24px;
+            border-style: solid;
+            border-radius: 10px 25px;
+            border-width: 3px;
+            border-color: var(--plasmapy-darkblue)">
+    <p class="plasmapy-note-title" style="border-top-left-radius: 8px; border-top-right-radius: 23px ">
+        Hack Week Pages
+    </p>
+    <p style="margin-bottom: 0">
+        <a href="../about">About</a><br>
+        <a href="../registration">Registration</a><br>
+        <a href="../schedule">Schedule</a><br>
+        <!--
+        <a href="../python">Python Tutorials</a><br>
+        <a href="../tutorials">Tutorials</a><br>
+        <a href="../install">Software Installation</a><br>
+        <a href="../social">Social Events</a><br>
+        -->
+        <a href="../committee">Organizing Committee</a><br>
+        <!--
+        <a href="../exit_survey">How did we do?</a><br>
+        <a href="https://youtube.com/playlist?list=PLKpKGRIZZV_R2ZnpbSZ5-Qm2bpUMZs7by">YouTube Playlist</a>
+        -->
+    </p>
+</div>
+
+Welcome to the first **PlasmaPy Summer School**! This event will be held
+at Bryn Mawr College near Philadelphia from 2024 July 29 – August 1, with the final day 
+being an optional hack session.  This summer school will cover the 
+essentials of contributing to an open source Python project like PlasmaPy.  
+
+For information on registering please visit our 
+[registration page](../registration).

--- a/pages/2024/registration.md
+++ b/pages/2024/registration.md
@@ -1,0 +1,25 @@
+title: 2022 Hack Week Registration
+hidetitle: True
+
+# Plasma Hack Week 2022: Registration
+
+<div style="width: 100%; margin: 24px">
+    <a href=https://docs.google.com/forms/d/e/1FAIpQLSfRURsxZ3geqs1-1f3ZMUrKtP42uIyDLD0ewfbHBGkVhPgTxQ/viewform?usp=sf_link
+            class="feature-card feature-link btn-plasmapy-bluegreen" 
+            style="width: 200px">
+        <div>Registration Form</div>
+    </a>
+</div>
+
+Registration and attendance for the **Plasma Hack Week** is completely **FREE**.
+The registration form will collect basic info, so we can keep you informed about
+the Hack Week and tailor topics to your interests, as best as we can, during the
+event.
+
+The registration form has an option to propose a **lightning talk** if you
+are interested in giving one.  A lightning talk is a short, informal
+talk on any topic of interest to Hack Week participants.
+
+<!--
+For more information on lightning talks, see the [schedule page](../schedule).
+-->

--- a/pages/2024/schedule.md
+++ b/pages/2024/schedule.md
@@ -1,0 +1,20 @@
+title: PlasmaPy Summer School 2024 Schedule
+hidetitle: True
+
+# PlasmaPy Summer School 2024: Schedule
+
+**Dates:** July 29 to August 1, 2024 
+<!--
+<br>
+**Times:** 11:00 am to 4:00 pm EDT 
+-->
+
+The PlasmaPy Summer School 2024 will be held from July 29 – August 1,
+with the final day being an optional hack session.  
+
+The primary goal of this year's event is to teach members of the plasma
+community the skills needed to contribute to an open source Python
+foundational topics and progress to more advanced topics as the week
+proceeds.
+
+The schedule will be posted soon.


### PR DESCRIPTION
We are in the process of organizing a summer school to provide members of the plasma community an opportunity to learn how to contribute to open source projects like PlasmaPy.  This event is expected to be held at Bryn Mawr College near Philadelphia from July 29 – August 1, 2024.  The first three days will have a format akin to a summer school, and the final day will be an unstructured, informal hack session.  This PR begins the webpage for this event.